### PR TITLE
fix erc20 build, it needed a module

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,12 +79,11 @@ build-and-test:
     - ./build.sh
     - cd -
     - echo "_____Downloading the latest nightly Substrate_____"
-    # CI passes with this and below versions until the issue is solved: https://github.com/paritytech/srml-contracts-waterfall/issues/27
     # - curl https://releases.parity.io/substrate/x86_64-debian:stretch/2.0.0-21e4f08/substrate/substrate --output substrate --location
     # master from gitlab
     # - curl "https://gitlab.parity.io/parity/substrate/-/jobs/artifacts/master/download?job=build-linux-substrate" --output artifacts.zip --location
     # published master
-    - curl "https://releases.parity.io/substrate/x86_64-debian:stretch/latest/substrate" --output substrate --location
+    - curl "https://releases.parity.io/substrate/x86_64-debian:stretch/latest/substrate/substrate" --output substrate --location
     - chmod +x ./substrate
     - export SUBSTRATE_PATH="./substrate"
     - $SUBSTRATE_PATH --version

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,11 +67,15 @@ build-and-test:
     - ./build.sh
     - cd -
     - cd contracts/assemblyscript/flipper
-    - yarn && yarn build
+    - yarn
+    - yarn add assemblyscript
+    - yarn build
     - ./build.sh
     - cd -
     - cd contracts/assemblyscript/incrementer
-    - yarn && yarn build
+    - yarn
+    - yarn add assemblyscript
+    - yarn build
     - ./build.sh
     - cd -
     - cd contracts/assemblyscript/erc20
@@ -81,20 +85,12 @@ build-and-test:
     - ./build.sh
     - cd -
     - echo "_____Downloading the latest nightly Substrate_____"
-<<<<<<< HEAD
-    # - curl https://releases.parity.io/substrate/x86_64-debian:stretch/2.0.0-21e4f08/substrate/substrate --output substrate --location
-=======
     # CI passes with this and below versions until the issue is solved: https://github.com/paritytech/srml-contracts-waterfall/issues/27
     # - curl https://releases.parity.io/substrate/x86_64-debian:stretch/2.0.0-21e4f08/substrate/substrate --output substrate --location 
->>>>>>> e4d8829b4e3bc44382b15104fb70a4067336c3de
     # master from gitlab
     # - curl "https://gitlab.parity.io/parity/substrate/-/jobs/artifacts/master/download?job=build-linux-substrate" --output artifacts.zip --location 
     # published master
-<<<<<<< HEAD
     - curl "https://releases.parity.io/substrate/x86_64-debian:stretch/latest/substrate/substrate" --output substrate --location
-=======
-    - curl "https://releases.parity.io/substrate/x86_64-debian:stretch/latest/substrate" --output substrate --location 
->>>>>>> e4d8829b4e3bc44382b15104fb70a4067336c3de
     - chmod +x ./substrate
     - export SUBSTRATE_PATH="./substrate"
     - $SUBSTRATE_PATH --version

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,9 @@ build-and-test:
     - ./build.sh
     - cd -
     - cd contracts/assemblyscript/erc20
-    - yarn && yarn build
+    - yarn
+    - yarn add assemblyscript
+    - yarn build
     - ./build.sh
     - cd -
     - echo "_____Downloading the latest nightly Substrate_____"

--- a/build.sh
+++ b/build.sh
@@ -17,13 +17,17 @@ cd -
 
 cd contracts/assemblyscript/flipper
 rm -rf build
-yarn && yarn build
+yarn
+yarn add assemblyscript
+yarn build
 ./build.sh
 cd -
 
 cd contracts/assemblyscript/incrementer
 rm -rf build
-yarn && yarn build
+yarn
+yarn add assemblyscript
+yarn build
 ./build.sh
 cd -
 

--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,8 @@ cd -
 
 cd contracts/assemblyscript/erc20
 rm -rf build
-yarn && yarn build
+yarn
+yarn add assemblyscript
+yarn build
 ./build.sh
 cd -


### PR DESCRIPTION
This PR fixes CI issues.
CI still has a place for improvement i.e. being triggered from substrate CI it should run that pipeline's binary.