### PR TITLE
Reflect breaking RPC changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint": "^6.6.0",
     "jest": "^24.9.0",
     "ts-jest": "^24.1.0",
-    "ts-loader": "^5.3.2"
+    "ts-loader": "^5.3.3"
   },
   "jest": {
     "preset": "ts-jest/presets/js-with-ts"

--- a/tests/contracts-assemblyscript.spec.ts
+++ b/tests/contracts-assemblyscript.spec.ts
@@ -40,7 +40,7 @@ let contractCreator: KeyringPair;
 let api: ApiPromise;
 
 beforeAll((): void => {
-  jest.setTimeout(70000);
+  jest.setTimeout(30000);
 });
 
 beforeEach(
@@ -52,7 +52,7 @@ beforeEach(
       .transfer(contractCreator.address, CREATION_FEE.muln(5))
       .signAndSend(BOB, (result: SubmittableResult): void => {
         if (
-          result.status.isFinalized &&
+          result.status.isInBlock &&
           result.findRecord("system", "ExtrinsicSuccess")
         ) {
           console.log("New test account has been created.");
@@ -164,7 +164,7 @@ describe("AssemblyScript Smart Contracts", () => {
     await api.tx.balances
       .transfer(DAN.address, CREATION_FEE.muln(5))
       .signAndSend(ALICE, (result: SubmittableResult): void => {
-        if (result.status.isFinalized && result.findRecord("system", "ExtrinsicSuccess")) {
+        if (result.status.isInBlock && result.findRecord("system", "ExtrinsicSuccess")) {
           console.log("DANs account is now funded.");
         }
       });

--- a/tests/contracts-rust.spec.ts
+++ b/tests/contracts-rust.spec.ts
@@ -37,7 +37,7 @@ let testAccount: KeyringPair;
 let api: ApiPromise;
 
 beforeAll((): void => {
-  jest.setTimeout(100000);
+  jest.setTimeout(30000);
 });
 
 beforeEach(
@@ -49,7 +49,7 @@ beforeEach(
       .transfer(testAccount.address, CREATION_FEE.muln(3))
       .signAndSend(alicePair, (result: SubmittableResult): void => {
         if (
-          result.status.isFinalized &&
+          result.status.isInBlock &&
           result.findRecord("system", "ExtrinsicSuccess")
         ) {
           console.log("New test account has been created.");

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, SubmittableResult } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { Option } from "@polkadot/types";
-import { AccountId, ContractInfo, Hash, StorageData } from "@polkadot/types/interfaces";
+import { Address, ContractInfo, Hash, StorageData } from "@polkadot/types/interfaces";
 import { u8aToHex } from "@polkadot/util";
 import BN from "bn.js";
 import fs from "fs";
@@ -56,7 +56,7 @@ export async function instantiate(
   inputData: any,
   endowment: BN,
   gasRequired: number = GAS_REQUIRED
-): Promise<AccountId> {
+): Promise<Address> {
   const tx = api.tx.contracts.instantiate(
     endowment,
     gasRequired,
@@ -69,20 +69,20 @@ export async function instantiate(
   if (!record) {
     console.error("ERROR: No new instantiated contract");
   }
-  // Return the AccountId of instantiated contract.
+  // Return the Address of instantiated contract.
   return record.event.data[1];
 }
 
 export async function callContract(
   api: ApiPromise,
   signer: KeyringPair,
-  contractAccountId: AccountId,
+  contractAddress: Address,
   inputData: any,
   gasRequired: number = GAS_REQUIRED,
   endowment: number = 0
 ): Promise<void> {
   const tx = api.tx.contracts.call(
-    contractAccountId,
+    contractAddress,
     endowment,
     gasRequired,
     inputData
@@ -93,11 +93,11 @@ export async function callContract(
 
 export async function getContractStorage(
   api: ApiPromise,
-  contractAccountId: AccountId,
+  contractAddress: Address,
   storageKey: Uint8Array
 ): Promise<StorageData> {
   const contractInfo = await api.query.contracts.contractInfoOf(
-    contractAccountId
+    contractAddress
   );
 
   // Return the value of the contracts storage

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,132 +302,132 @@
     "@types/yargs" "^13.0.0"
 
 "@polkadot/api-contract@beta":
-  version "1.4.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-contract/-/api-contract-1.4.0-beta.17.tgz#f8f95498d0223486478a419586788477011ef17a"
-  integrity sha512-jSka8p9UW7ZUR0+2WYTaqN3m37douIUw8RKHHIiIFMz2iWOMULles7YUeOZCwI/BLTZyd3N15NRubsb/vbogmQ==
+  version "1.4.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-contract/-/api-contract-1.4.0-beta.39.tgz#c74cfd375983271f7bd14bc8595dad9e08a16daa"
+  integrity sha512-JDIWo/Ks8w59gtsYEIKQAfODc3XZKLO40Jn5gpmlWJesCXx0z+5RTmgYNmYQW6OunEF0MlEBj2OsFJFKKhcIaQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/api" "1.4.0-beta.17"
-    "@polkadot/rpc-core" "1.4.0-beta.17"
-    "@polkadot/types" "1.4.0-beta.17"
-    "@polkadot/util" "^2.4.1"
+    "@polkadot/api" "1.4.0-beta.39"
+    "@polkadot/rpc-core" "1.4.0-beta.39"
+    "@polkadot/types" "1.4.0-beta.39"
+    "@polkadot/util" "^2.5.1"
     bn.js "^5.1.1"
     rxjs "^6.5.4"
 
-"@polkadot/api-derive@1.4.0-beta.17":
-  version "1.4.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.4.0-beta.17.tgz#dd0704d372125390101eb234ad653af8f3a730fc"
-  integrity sha512-+tutOqyQpzxR1zALkjPp10O4CWIWpxE2q34ZTy7lJCk7RXQeAsjS9HwF11JeoZIjmmZZFzTAB4Nh8afYOwqZ7w==
+"@polkadot/api-derive@1.4.0-beta.39":
+  version "1.4.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.4.0-beta.39.tgz#28d7cd8dc42a57aeb044ea5dafd1763e190614c6"
+  integrity sha512-ZhSFH43HidboEb77mcNpwu6n531xQjMWujA48Vs5J/zPb+tSw5/qUqNNqBmKEjA1EmBWleDNarCw08DCWuZl7g==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/api" "1.4.0-beta.17"
-    "@polkadot/rpc-core" "1.4.0-beta.17"
-    "@polkadot/rpc-provider" "1.4.0-beta.17"
-    "@polkadot/types" "1.4.0-beta.17"
-    "@polkadot/util" "^2.4.1"
-    "@polkadot/util-crypto" "^2.4.1"
+    "@polkadot/api" "1.4.0-beta.39"
+    "@polkadot/rpc-core" "1.4.0-beta.39"
+    "@polkadot/rpc-provider" "1.4.0-beta.39"
+    "@polkadot/types" "1.4.0-beta.39"
+    "@polkadot/util" "^2.5.1"
+    "@polkadot/util-crypto" "^2.5.1"
     bn.js "^5.1.1"
     memoizee "^0.4.14"
     rxjs "^6.5.4"
 
-"@polkadot/api@1.4.0-beta.17", "@polkadot/api@beta":
-  version "1.4.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.4.0-beta.17.tgz#dfcf7be494feebf38106e6757227bac3eba13060"
-  integrity sha512-pCnA0B/HCdrXEZ4Rgj+Svl/Mzjg/NwBjpnV7JofXM93xXY76NIOSRyoMh4ZAcHKmw39R6W4bQZPh5fArDesbtQ==
+"@polkadot/api@1.4.0-beta.39", "@polkadot/api@beta":
+  version "1.4.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.4.0-beta.39.tgz#d707e7db2ad0fe3565e4ef4ac7cd145444936eae"
+  integrity sha512-29+lMIcy1fDIsOKTDPoIZJI8zNcovyZ3IJUuM0nr3OKCzcnbBfKBbEHw5bdWlxfMqcEULIuCSLUbV81ydqGOTA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/api-derive" "1.4.0-beta.17"
-    "@polkadot/keyring" "^2.4.1"
-    "@polkadot/metadata" "1.4.0-beta.17"
-    "@polkadot/rpc-core" "1.4.0-beta.17"
-    "@polkadot/rpc-provider" "1.4.0-beta.17"
-    "@polkadot/types" "1.4.0-beta.17"
-    "@polkadot/util" "^2.4.1"
-    "@polkadot/util-crypto" "^2.4.1"
+    "@polkadot/api-derive" "1.4.0-beta.39"
+    "@polkadot/keyring" "^2.5.1"
+    "@polkadot/metadata" "1.4.0-beta.39"
+    "@polkadot/rpc-core" "1.4.0-beta.39"
+    "@polkadot/rpc-provider" "1.4.0-beta.39"
+    "@polkadot/types" "1.4.0-beta.39"
+    "@polkadot/util" "^2.5.1"
+    "@polkadot/util-crypto" "^2.5.1"
     bn.js "^5.1.1"
     eventemitter3 "^4.0.0"
     rxjs "^6.5.4"
 
-"@polkadot/jsonrpc@1.4.0-beta.17":
-  version "1.4.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-1.4.0-beta.17.tgz#ac031fbd1a6fa28ff8caa3afade1cd8cfd5aa7e7"
-  integrity sha512-eiVyUIuAdrs12Oh8EZHxd62FiVH4mw5c2jaJTSm/WavnZMJ/wpo5oePHj/yekr/mFR0io6sKP4n8edLYN7enRA==
+"@polkadot/jsonrpc@1.4.0-beta.39":
+  version "1.4.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@polkadot/jsonrpc/-/jsonrpc-1.4.0-beta.39.tgz#51acef6b5c207b0715aa883b1568538a61ebac71"
+  integrity sha512-Pn62fA+BrQu72bx4JXLMGCwi/fKVmr17cFQYZ9jThbxiH57If7f9yV5UKjGXBYwsyN8Pky8IAXJR+pii9n/qPg==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/types" "1.4.0-beta.17"
-    "@polkadot/util" "^2.4.1"
+    "@polkadot/types" "1.4.0-beta.39"
+    "@polkadot/util" "^2.5.1"
 
-"@polkadot/keyring@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-2.4.1.tgz#1f6e59dd55031481d3642f18e407141d596fd388"
-  integrity sha512-NBsw6ypCvTUNBUTB/LIZGcJE6R8qrsZ6CEa+Hu6uKrwhR/xjtPBCH2sPaXj+OeNAZ2sMQuEoUJlJUhYnMal2pg==
+"@polkadot/keyring@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-2.5.1.tgz#53a7368f20e40faea5904d89b96dc89975360a22"
+  integrity sha512-E6CdkHidW6CdP11sJv0Nq7sVPAAHSsIYdybPW34drVHjl11leho7WETIGkXGrbAFjj4bi6H2CFWfF4i0gh7qhg==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/util" "^2.4.1"
-    "@polkadot/util-crypto" "^2.4.1"
+    "@polkadot/util" "2.5.1"
+    "@polkadot/util-crypto" "2.5.1"
 
-"@polkadot/metadata@1.4.0-beta.17":
-  version "1.4.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.4.0-beta.17.tgz#c62b03e6973bfad9049c6c2761e73ef2d66ec439"
-  integrity sha512-Ky6lt4U9PqM/zBrdM0zeGAgU5dG8HzYoZQbKodwWnsLNWAYJZJBwBlRoZjDqkXr/MOmwoPl4V2YgwVVpjbpDCA==
+"@polkadot/metadata@1.4.0-beta.39":
+  version "1.4.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.4.0-beta.39.tgz#546a53b353d3c3f51a48aedc1534bbc3a9fa8b57"
+  integrity sha512-WLhQPxX82QJXOFU85mLY4R25x+9z5RKbiduBKr5/ZcUYaWP+gDsEfPKjSux0Znw8XGiAhIi4FNobmhWEqDW8KA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/types" "1.4.0-beta.17"
-    "@polkadot/util" "^2.4.1"
-    "@polkadot/util-crypto" "^2.4.1"
+    "@polkadot/types" "1.4.0-beta.39"
+    "@polkadot/util" "^2.5.1"
+    "@polkadot/util-crypto" "^2.5.1"
     bn.js "^5.1.1"
 
-"@polkadot/rpc-core@1.4.0-beta.17":
-  version "1.4.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.4.0-beta.17.tgz#a203557d3aeb0461baab5eb9aafec1e1f1255968"
-  integrity sha512-VDtcPw9suKlvNVfXmJnUWjhUOSvGanQ2r970kfDGdvlSBhv8xR9AeYEuakwCMIZJn4rTl4yFrzomo9howeyY5Q==
+"@polkadot/rpc-core@1.4.0-beta.39":
+  version "1.4.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.4.0-beta.39.tgz#9b24b2de63862cd5574d77cfae4bc69132b08601"
+  integrity sha512-GbIrQRvkDEgIwfKRN+xiMvRK8x+e1NaoSdYt/VPh/8xYUce0QwL04Fd+cft3A+pkjpUCJF6Hr83dFVflUOMmgQ==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/jsonrpc" "1.4.0-beta.17"
-    "@polkadot/metadata" "1.4.0-beta.17"
-    "@polkadot/rpc-provider" "1.4.0-beta.17"
-    "@polkadot/types" "1.4.0-beta.17"
-    "@polkadot/util" "^2.4.1"
+    "@polkadot/jsonrpc" "1.4.0-beta.39"
+    "@polkadot/metadata" "1.4.0-beta.39"
+    "@polkadot/rpc-provider" "1.4.0-beta.39"
+    "@polkadot/types" "1.4.0-beta.39"
+    "@polkadot/util" "^2.5.1"
     memoizee "^0.4.14"
     rxjs "^6.5.4"
 
-"@polkadot/rpc-provider@1.4.0-beta.17":
-  version "1.4.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.4.0-beta.17.tgz#9fc8c1486c353f98be909752c01de667f15d3812"
-  integrity sha512-6XqMqFAVwf9oSBB+VtYPjhfqddUllH56Sn+uiH0HIc/ZZO2NKOAZxuzaB4TnCzw4nMPOFy8P60enZCnbGYxVQQ==
+"@polkadot/rpc-provider@1.4.0-beta.39":
+  version "1.4.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.4.0-beta.39.tgz#6bb24ca1c8f6af07e73bf23db9f499f2d8678d34"
+  integrity sha512-hnUGLecvK9cazICzYcymJBui1syikRpOpd6gFQA8N1uiiBDcHgwJKP92Fe0buC4x2JbJVjnzN46e38uBm/66/w==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/jsonrpc" "1.4.0-beta.17"
-    "@polkadot/metadata" "1.4.0-beta.17"
-    "@polkadot/types" "1.4.0-beta.17"
-    "@polkadot/util" "^2.4.1"
-    "@polkadot/util-crypto" "^2.4.1"
+    "@polkadot/jsonrpc" "1.4.0-beta.39"
+    "@polkadot/metadata" "1.4.0-beta.39"
+    "@polkadot/types" "1.4.0-beta.39"
+    "@polkadot/util" "^2.5.1"
+    "@polkadot/util-crypto" "^2.5.1"
     bn.js "^5.1.1"
     eventemitter3 "^4.0.0"
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
-"@polkadot/types@1.4.0-beta.17":
-  version "1.4.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.4.0-beta.17.tgz#bd4fd5b07ce4c159a51775881a58cd636524f092"
-  integrity sha512-eJS0F7LobiEO27zD/45ZR37Q1SH5SkVbhXFNH7cTa81Hpz5xJwui9mMW9fcZTOwmKlWeDnyB99gtJOkzQx7Ndw==
+"@polkadot/types@1.4.0-beta.39":
+  version "1.4.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.4.0-beta.39.tgz#eb4aaca94a7719f4a6615f3aabf5409e7f936753"
+  integrity sha512-BxWLYMsPJxrDH3T13Re8xuJCG8N+ppvCPM8kF59DCmWCg5AJFkoHuBKR01jR+ahrWMrXjGl7YFCEx3Jn5zbIcA==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/metadata" "1.4.0-beta.17"
-    "@polkadot/util" "^2.4.1"
-    "@polkadot/util-crypto" "^2.4.1"
+    "@polkadot/metadata" "1.4.0-beta.39"
+    "@polkadot/util" "^2.5.1"
+    "@polkadot/util-crypto" "^2.5.1"
     "@types/bn.js" "^4.11.6"
     bn.js "^5.1.1"
     memoizee "^0.4.14"
     rxjs "^6.5.4"
 
-"@polkadot/util-crypto@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-2.4.1.tgz#f02e4dca225882c7f1a7762bc416530567c4803c"
-  integrity sha512-5mPuRhpvYXeLqqGEqOtJqp+lZCr1Z2NIxIKgabaFfrp1malbgWhKDnafkAg7kwL3BrRQbOge0vgK6VmDiuXljQ==
+"@polkadot/util-crypto@2.5.1", "@polkadot/util-crypto@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-2.5.1.tgz#9dceda1b2a6684d077ebe2981c4e0dbc69a52fd0"
+  integrity sha512-AhL37ffn8MkSNwg//uj/xYFYzdbR3h196UB7y3IN6CPhD+pOPZOqDpqdd0oT2xpksppctvWZqYEaT1k7l3R2Tw==
   dependencies:
     "@babel/runtime" "^7.8.4"
-    "@polkadot/util" "^2.4.1"
+    "@polkadot/util" "2.5.1"
     "@polkadot/wasm-crypto" "^1.0.1"
     base-x "^3.0.7"
     bip39 "^3.0.2"
@@ -440,10 +440,10 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-2.4.1.tgz#7c0d0619af6ced647e99d6bc8ccc24bc3202a2a7"
-  integrity sha512-60yBpgYgowx/TVuJyrjYYIJJpw4aCNzay8imy5L2Fug2y3lvgrHyTxPAgrykOmuFeZ3jq9ayjXk5bpAJ179vFg==
+"@polkadot/util@2.5.1", "@polkadot/util@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-2.5.1.tgz#8b4be9f7418a2872f6ccb1a0d18e426b4e8779a9"
+  integrity sha512-MVQPyxkhfERvV1uGyne0b7iekX9h7v892144bNB5VYZ7C2rTuJ5XpaWgx0V9DANeaEv+cqfjeW+8ngYQwYhQKw==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@types/bn.js" "^4.11.6"
@@ -463,9 +463,9 @@
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
 "@types/babel__core@^7.1.0":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.4.tgz#5c5569cc40e5f2737dfc00692f5444e871e4a234"
-  integrity sha512-c/5MuRz5HM4aizqL5ViYfW4iEnmfPcfbH4Xa6GgLT21dMc1NGeNnuS6egHheOmP+kCJ9CAzC4pv4SDCWTnRkbg==
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.5.tgz#e4d84704b4df868b3ad538365a13da2fa6dbc023"
+  integrity sha512-+ckxwNj892FWgvwrUWLOghQ2JDgOgeqTPwrcl+0t1pG59CP8qMJ6S/efmEd999vCFSJKOpyMakvU+w380rduUQ==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -489,9 +489,9 @@
     "@babel/types" "^7.0.0"
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
-  version "7.0.8"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.8.tgz#479a4ee3e291a403a1096106013ec22cf9b64012"
-  integrity sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.9.tgz#be82fab304b141c3eee81a4ce3b034d0eba1590a"
+  integrity sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==
   dependencies:
     "@babel/types" "^7.3.0"
 
@@ -663,9 +663,9 @@ acorn@^7.1.0:
   integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
 ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.11.0.tgz#c3607cbc8ae392d8a5a536f25b21f8e5f3f87fe9"
-  integrity sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
+  integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -4423,7 +4423,7 @@ ts-jest@^24.1.0:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-loader@^5.3.2:
+ts-loader@^5.3.3:
   version "5.4.5"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.4.5.tgz#a0c1f034b017a9344cef0961bfd97cc192492b8b"
   integrity sha512-XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==
@@ -4435,9 +4435,9 @@ ts-loader@^5.3.2:
     semver "^5.0.1"
 
 tslib@^1.8.1, tslib@^1.9.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.0.tgz#f1f3528301621a53220d58373ae510ff747a66bc"
+  integrity sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -4493,9 +4493,9 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 typescript@^3.6.4:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
+  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Fixes significantly longer execution times for tests after https://github.com/polkadot-js/api/releases/tag/v1.2.1 got merged.
The cause was the rename of `isFinalized()` to `isInBlock()` 