### PR TITLE
Solang Flipper test fixed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,3 +51,7 @@ yarn
 yarn build
 ./build.sh
 cd -
+
+cd contracts/solidity/flipper
+./build.sh
+cd -

--- a/contracts/solidity/flipper/flipper.sol
+++ b/contracts/solidity/flipper/flipper.sol
@@ -1,4 +1,4 @@
-contract flipper {
+contract Flipper {
 	bool private value;
 
 	constructor(bool initvalue) public {

--- a/tests/contracts-solidity.spec.ts
+++ b/tests/contracts-solidity.spec.ts
@@ -69,7 +69,7 @@ describe("Solang Smart Contracts", () => {
     const codeHash = await putCode(
       api,
       contractCreator,
-      "../contracts/solidity/flipper/flipper.wasm"
+      "../contracts/solidity/flipper/Flipper.wasm"
     );
     expect(codeHash).toBeDefined();
 
@@ -79,7 +79,7 @@ describe("Solang Smart Contracts", () => {
       api,
       contractCreator,
       codeHash,
-      "0xd531178600",
+      "0xf81e7e1a00",
       CREATION_FEE
     );
     expect(address).toBeDefined();
@@ -92,12 +92,12 @@ describe("Solang Smart Contracts", () => {
     expect(initialValue).toBeDefined();
     expect(initialValue.toString()).toEqual("0x00");
 
-    await callContract(api, contractCreator, address, "0xa9efe4cd");
+    await callContract(api, contractCreator, address, "0xcde4efa9");
 
     const newValue = await getContractStorage(api, address, STORAGE_KEY);
     expect(newValue.toString()).toEqual("0x01");
 
-    await callContract(api, contractCreator, address, "0xa9efe4cd");
+    await callContract(api, contractCreator, address, "0xcde4efa9");
 
     const flipBack = await getContractStorage(api, address, STORAGE_KEY);
     expect(flipBack.toString()).toEqual("0x00");

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,121 +302,133 @@
     "@types/yargs" "^13.0.0"
 
 "@polkadot/api-contract@^1.9.0-beta.22":
-  version "1.9.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-contract/-/api-contract-1.9.0-beta.22.tgz#ee4dfc0890fcd8261d969a20dca6c7c1ba168a83"
-  integrity sha512-KlKZ6oGryUfsNRf6XYGbM3Gt3oinV0RNfdyKpSHopWK2oHaFJZrO28WxtqDiYn/MBxxYUaCnGofOQmCNkuG3kw==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-contract/-/api-contract-1.9.1.tgz#ca241cb69008c382ecfdb08519859773da32efdb"
+  integrity sha512-iBNJjlvquZj76HQJQ1xpH2SK5GtfBtGkKFjwqel5PxITNcWUnlsqB9+IeNGSPq7kRKaaZyxpeP62wF0vWGtV1Q==
   dependencies:
     "@babel/runtime" "^7.9.2"
-    "@polkadot/api" "1.9.0-beta.22"
-    "@polkadot/rpc-core" "1.9.0-beta.22"
-    "@polkadot/types" "1.9.0-beta.22"
-    "@polkadot/util" "^2.7.0-beta.8"
+    "@polkadot/api" "1.9.1"
+    "@polkadot/rpc-core" "1.9.1"
+    "@polkadot/types" "1.9.1"
+    "@polkadot/util" "^2.7.1"
     bn.js "^5.1.1"
     rxjs "^6.5.4"
 
-"@polkadot/api-derive@1.9.0-beta.22":
-  version "1.9.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.9.0-beta.22.tgz#7c32c3ea21301e1ae22e84e850c89fe0447d5d90"
-  integrity sha512-4fxjIRx4C2UDJTUYvJspnThLVlAdYUM9KVAcOfPfXuL+zKgRJhwYVs2u5Qti3b0M4HeneFZS9ZGXTZwJbfNwdw==
+"@polkadot/api-derive@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.9.1.tgz#0b0fb580d3d5c42570207ee36a8652b21f51a556"
+  integrity sha512-aktzdVHpEPGqtRNCjjuSFS9Crt5S1JSDYDKq6BvK0tDNAxfNfeD2e73P9kPPNhuC8R50bD5sMmSvsJS0PQTULw==
   dependencies:
     "@babel/runtime" "^7.9.2"
-    "@polkadot/api" "1.9.0-beta.22"
-    "@polkadot/rpc-core" "1.9.0-beta.22"
-    "@polkadot/rpc-provider" "1.9.0-beta.22"
-    "@polkadot/types" "1.9.0-beta.22"
-    "@polkadot/util" "^2.7.0-beta.8"
-    "@polkadot/util-crypto" "^2.7.0-beta.8"
+    "@polkadot/api" "1.9.1"
+    "@polkadot/rpc-core" "1.9.1"
+    "@polkadot/rpc-provider" "1.9.1"
+    "@polkadot/types" "1.9.1"
+    "@polkadot/util" "^2.7.1"
+    "@polkadot/util-crypto" "^2.7.1"
     bn.js "^5.1.1"
     memoizee "^0.4.14"
     rxjs "^6.5.4"
 
-"@polkadot/api@1.9.0-beta.22", "@polkadot/api@^1.9.0-beta.22":
-  version "1.9.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.9.0-beta.22.tgz#c38013928ff45dac038ac5ed78d58673f303bb88"
-  integrity sha512-6AyVG1j99iTCuHa6lsaiqYatPEyDfotrQ6OdaJ2XwaHRpBrzFTfw62uH4WjievWnmHSxG+ewBSierkmipmIHUw==
+"@polkadot/api@1.9.1", "@polkadot/api@^1.9.0-beta.22":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.9.1.tgz#10956c3c07bf6ba132f94722bd4bc23d536a7296"
+  integrity sha512-dJlWvpilZCVdRgZ2HsG6fwkNGuHomfqHfjMMPPz1yLdnMybWpsWYxK5cYfYZ3Y9EI0KSv0W+ZU0o6LnQyE/lAA==
   dependencies:
     "@babel/runtime" "^7.9.2"
-    "@polkadot/api-derive" "1.9.0-beta.22"
-    "@polkadot/keyring" "^2.7.0-beta.8"
-    "@polkadot/metadata" "1.9.0-beta.22"
-    "@polkadot/rpc-core" "1.9.0-beta.22"
-    "@polkadot/rpc-provider" "1.9.0-beta.22"
-    "@polkadot/types" "1.9.0-beta.22"
-    "@polkadot/util" "^2.7.0-beta.8"
-    "@polkadot/util-crypto" "^2.7.0-beta.8"
+    "@polkadot/api-derive" "1.9.1"
+    "@polkadot/keyring" "^2.7.1"
+    "@polkadot/metadata" "1.9.1"
+    "@polkadot/rpc-core" "1.9.1"
+    "@polkadot/rpc-provider" "1.9.1"
+    "@polkadot/types" "1.9.1"
+    "@polkadot/types-known" "1.9.1"
+    "@polkadot/util" "^2.7.1"
+    "@polkadot/util-crypto" "^2.7.1"
     bn.js "^5.1.1"
     eventemitter3 "^4.0.0"
     rxjs "^6.5.4"
 
-"@polkadot/keyring@^2.7.0-beta.8":
-  version "2.7.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-2.7.0-beta.8.tgz#bdb803c714a9292d03d4d24838ece356f32b6f32"
-  integrity sha512-3DEw0wTCkNf9JASR3h5I9xiipWrhHMPioL80EspqJQ6XiXnMAckvULntLXCnVrOIMIpXdzHNkyxmz/QYf1l7kg==
+"@polkadot/keyring@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-2.7.1.tgz#714d564b80305a343d83ff07baae59173af5f463"
+  integrity sha512-aQkc6TT0kaLwEa7rxit/M6/uWJ03wWY1owZychW9slfXH/tmWMCSM0m6z78MIAzdnSTVY7ztpjDfxrPOCHlLYA==
   dependencies:
     "@babel/runtime" "^7.9.2"
-    "@polkadot/util" "2.7.0-beta.8"
-    "@polkadot/util-crypto" "2.7.0-beta.8"
+    "@polkadot/util" "2.7.1"
+    "@polkadot/util-crypto" "2.7.1"
 
-"@polkadot/metadata@1.9.0-beta.22":
-  version "1.9.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.9.0-beta.22.tgz#0177fdc97c0a9c15a8f7dbbcd800e8c4f6a5e945"
-  integrity sha512-f3GlQ7eIjuddbtFimifJTSvMeA1ufard56DzmBHKa2ylo9v1rs7sZPjSrfjzWeBv7b+p1T2KCMQNmbSj1Twg5w==
+"@polkadot/metadata@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.9.1.tgz#8f2453fe981bbbc6a3aba333f209195e5faff166"
+  integrity sha512-xGDto2AGSXRx3nMfqLIK0D15gJwuowL4D+RdLFC7rA6pMBCM2Ja4uVDD+f76IN0aF+/1p+4dTN1FGkuNMPSqAg==
   dependencies:
     "@babel/runtime" "^7.9.2"
-    "@polkadot/types" "1.9.0-beta.22"
-    "@polkadot/util" "^2.7.0-beta.8"
-    "@polkadot/util-crypto" "^2.7.0-beta.8"
+    "@polkadot/types" "1.9.1"
+    "@polkadot/types-known" "1.9.1"
+    "@polkadot/util" "^2.7.1"
+    "@polkadot/util-crypto" "^2.7.1"
     bn.js "^5.1.1"
 
-"@polkadot/rpc-core@1.9.0-beta.22":
-  version "1.9.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.9.0-beta.22.tgz#6813ff1c8640253578a30252972b3d9da3b8f0fa"
-  integrity sha512-LODFJwBaBUGgefvOqwrF8v+0xetti0+9/XkqWqYg6fLDlwzO5vk8tRzelULTc0WrfYQp8QQDS6ELy3rM6ucGjA==
+"@polkadot/rpc-core@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.9.1.tgz#40cab586bba133a0a80481a8a4f81082e62bf08d"
+  integrity sha512-9CnhCSF4maNzaD6n9O2aYQvbEqqHIZdA2XOFZ+Tjauo2YOvgskC7VAD3gjS2aJ8HcwKY2vaRpgp/lRFnt8+rMg==
   dependencies:
     "@babel/runtime" "^7.9.2"
-    "@polkadot/metadata" "1.9.0-beta.22"
-    "@polkadot/rpc-provider" "1.9.0-beta.22"
-    "@polkadot/types" "1.9.0-beta.22"
-    "@polkadot/util" "^2.7.0-beta.8"
+    "@polkadot/metadata" "1.9.1"
+    "@polkadot/rpc-provider" "1.9.1"
+    "@polkadot/types" "1.9.1"
+    "@polkadot/util" "^2.7.1"
     memoizee "^0.4.14"
     rxjs "^6.5.4"
 
-"@polkadot/rpc-provider@1.9.0-beta.22":
-  version "1.9.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.9.0-beta.22.tgz#2053f1c8a812be96a6051ea7d099fc9cbca5472e"
-  integrity sha512-1RG8IbZbcuAJO10YFPHyEOagWU4HC68/Mb6Fc9LA63xpno41fiZkWEi2DsjxIl/GTvKx2yxKay/9sI5niZTGlg==
+"@polkadot/rpc-provider@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.9.1.tgz#06c511a3a71b5ec2c5b15b0e07c6203f01e4c994"
+  integrity sha512-HW3p9Z3eltqot1qReEwO8EcyBeyh+GZdp3Mb5l1cH9rjKm7GTc7tPpGgLzQP1DBgJMdUpxlPfZ4wZHJO6JresA==
   dependencies:
     "@babel/runtime" "^7.9.2"
-    "@polkadot/metadata" "1.9.0-beta.22"
-    "@polkadot/types" "1.9.0-beta.22"
-    "@polkadot/util" "^2.7.0-beta.8"
-    "@polkadot/util-crypto" "^2.7.0-beta.8"
+    "@polkadot/metadata" "1.9.1"
+    "@polkadot/types" "1.9.1"
+    "@polkadot/util" "^2.7.1"
+    "@polkadot/util-crypto" "^2.7.1"
     bn.js "^5.1.1"
     eventemitter3 "^4.0.0"
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
-"@polkadot/types@1.9.0-beta.22":
-  version "1.9.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.9.0-beta.22.tgz#5ca33cd5f833b3174fdf1c01588c8c48dd135550"
-  integrity sha512-6y8pK4Fqk1wRhXaiRAHbpJpdvHM+R5yiWHt9DFc1nCD61OOOEwrbjIc8xk69n4ykN7Sju0ur52C7qo6dKjG35g==
+"@polkadot/types-known@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.9.1.tgz#38f1d1ebaf77824066e9b78f82f336c269cc9d89"
+  integrity sha512-G0YUfEmrr9yW0Iz5SXXsO6zpkALUTLf4pocNY9ISeCjrUcdfk+Rt8OnsI2DRVC8Qjaf9a4rb9lC2HIMTqFJjgQ==
   dependencies:
     "@babel/runtime" "^7.9.2"
-    "@polkadot/metadata" "1.9.0-beta.22"
-    "@polkadot/util" "^2.7.0-beta.8"
-    "@polkadot/util-crypto" "^2.7.0-beta.8"
+    "@polkadot/types" "1.9.1"
+    "@polkadot/util" "^2.7.1"
+    bn.js "^5.1.1"
+
+"@polkadot/types@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.9.1.tgz#88d426241ace9e6ec3a2ce3e1a51d8333ad28822"
+  integrity sha512-c1mzuxJiOPIWrkEWMRdT2seW21lEC3C+EetshgCMXpcsAv5iQeB59J1fTbRiSsQIESKIiP/zv+Igpj7wO/2hMw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@polkadot/metadata" "1.9.1"
+    "@polkadot/util" "^2.7.1"
+    "@polkadot/util-crypto" "^2.7.1"
     "@types/bn.js" "^4.11.6"
     bn.js "^5.1.1"
     memoizee "^0.4.14"
     rxjs "^6.5.4"
 
-"@polkadot/util-crypto@2.7.0-beta.8", "@polkadot/util-crypto@^2.7.0-beta.8":
-  version "2.7.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-2.7.0-beta.8.tgz#2adb891cd755fbc1c9647b9fea86c3b7f1541530"
-  integrity sha512-315wO7N41BteRd3sIsbbH1Y9qNNYZiRl24Lh3TFgSiW5g4YuGjwRlHHjUoS+K+nn70UU3+4/0KXpX7CpxIa72A==
+"@polkadot/util-crypto@2.7.1", "@polkadot/util-crypto@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-2.7.1.tgz#627ff9aa29379da7c5aa3727829ae8a0e80cd7d8"
+  integrity sha512-8Y+9Fv0g/AfyJLB1a9WyCClzYuf9IVLRGhAcb0I4mAL/KqfHoEzGCBGd1PjmcRboOBrtq6IYTOppwA0c6WOGww==
   dependencies:
     "@babel/runtime" "^7.9.2"
-    "@polkadot/util" "2.7.0-beta.8"
+    "@polkadot/util" "2.7.1"
     "@polkadot/wasm-crypto" "^1.2.1"
     base-x "^3.0.8"
     bip39 "^3.0.2"
@@ -429,10 +441,10 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@2.7.0-beta.8", "@polkadot/util@^2.7.0-beta.8":
-  version "2.7.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-2.7.0-beta.8.tgz#8e3fa6c4dbc12a0cee5b9c4542c6e1cfc73ca3f1"
-  integrity sha512-gNudeHosA0ZbzOB4bLp7GQQs0XcVPBwEuSQsotbC+IgVIWhJZ0ZAhf/vwAXmHYJyzn8Nzvg17yjdW210b+H6bw==
+"@polkadot/util@2.7.1", "@polkadot/util@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-2.7.1.tgz#adc5b9c8ea17179e4ea2061ddee84d21a0d50cc2"
+  integrity sha512-bvYnqhXV3N8m+i92uq2XrqRi4DEUYgdMhDeCIzf0t8ZQ0mcGhhROMuULhlpT+IlHwAlfewQ17HwB2qLtB6mGLw==
   dependencies:
     "@babel/runtime" "^7.9.2"
     "@types/bn.js" "^4.11.6"
@@ -534,9 +546,9 @@
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
 "@types/node@*":
-  version "13.9.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.1.tgz#96f606f8cd67fb018847d9b61e93997dabdefc72"
-  integrity sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==
+  version "13.9.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.8.tgz#09976420fc80a7a00bf40680c63815ed8c7616f4"
+  integrity sha512-1WgO8hsyHynlx7nhP1kr0OFzsgKz5XDQL+Lfc3b1Q3qIln/n8cKD4m09NJ0+P1Rq7Zgnc7N0+SsMnoD1rEb0kA==
 
 "@types/node@11.11.6":
   version "11.11.6"


### PR DESCRIPTION
The failing test is fixed now.
The reason why it was failing is wrong selector used. There was a bug with Solang accepting any value as a selector, so the wrong selector was not detected before and the bug fix broke the test case.