### PR TITLE
[Merged by Bors] - Fixes for the build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/lib/ink
 /node_modules
 *.log
 /contracts/assemblyscript/**/node_modules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,10 +52,6 @@ build-and-test:
     - npm --version
     - wasm-prune -V
     - sccache -s
-    # `cargo install` returns an error if there is nothing to update, so have to supress it here temporarily
-    - cargo contract -V
-    - cargo install --git https://github.com/paritytech/cargo-contract --branch master || echo $?
-    - cargo contract -V
   script:
     - echo "_____Building contracts_____"
     - ./build.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/ink"]
-	path = lib/ink
-	url = https://github.com/paritytech/ink

--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,13 @@ if which podman || which docker || [ -n "$CI_JOB_ID" ]; then
     cd -; 
 else echo "Please install and run Docker or Podman if you want to compile the Solang contracts and succesfully run their tests.";
 fi
- 
-git submodule foreach git pull origin master
+
+if [[ -d lib/ink ]]; then
+	git --git-dir lib/ink/.git pull
+else
+	git clone --depth=1 --branch=master https://github.com/paritytech/ink.git lib/ink
+fi
+
 cd lib/ink/examples/flipper
 cargo +nightly contract build
 cargo +nightly contract generate-metadata

--- a/utils.sh
+++ b/utils.sh
@@ -79,7 +79,7 @@ function provide-parity-tools {
 
     export PATH=~/.cargo/bin:$PATH
 
-    cargo install --git https://github.com/paritytech/cargo-contract.git cargo-contract --force
+    cargo install cargo-contract
 
     if ! which wasm-prune; then
         cargo install pwasm-utils-cli --bin wasm-prune


### PR DESCRIPTION
I fixed some minor nits with the build scripts I had while executing them locally:

## Use cargo-contract from crates.io
cargo-contract latest stable suffices as it changes rarely and is mostly independend of substrate and ink.

This also removes the duplicate install instruction in the CI script which calls into `build.sh`.

## Remove submodule at it is never used as one
When you have a submodule and then every build you just check out some totally different hash you don't want a submodule. Just clone the current master in the build script and add it to gitignore. This resolves the annoyance of having a dirty index after every build.