### PR TITLE
change (CI): fix triggering; pin contracts image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ build-and-test:
   before_script:
     # upstream CI can override global vars here
     - unset CARGO_TARGET_DIR
-    - rustup +nightly show
+    - rustup show
     - cargo --version
     - yarn --version
     - npm --version

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,16 +13,16 @@ variables:                         &default-vars
   GIT_SUBMODULE_STRATEGY:          recursive
   GIT_DEPTH:                       100
   CARGO_INCREMENTAL:               0
-  REGISTRY:                        "paritytech"
 
 .docker-env:                       &docker-env
-  image:                           ${REGISTRY}/contracts-ci-linux:latest
+  image:                           paritytech/contracts-ci-linux:4e476221-20201029
   only:
     - master
     - /^v[0-9]+\.[0-9]+.*$/ # i.e. v1.0, v2.1rc1
     - schedules
     - web
     - branches
+    - triggers
   retry:
     max:                           2
     when:

--- a/build.sh
+++ b/build.sh
@@ -36,8 +36,8 @@ git submodule update --init --recursive
 
 echo "____Building ink! Examples____"
 cd lib/ink/examples/flipper
-cargo +nightly contract build
-cargo +nightly contract generate-metadata
+cargo +nightly-2020-10-01 contract build
+cargo +nightly-2020-10-01 contract generate-metadata
 cd -
 
 

--- a/contracts/rust/raw-incrementer/build.sh
+++ b/contracts/rust/raw-incrementer/build.sh
@@ -4,7 +4,7 @@ set -e
 
 PROJNAME=raw_incrementer
 
-cargo +nightly build --release
+cargo +nightly-2020-10-01 build --release
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/contracts/rust/restore-contract/build.sh
+++ b/contracts/rust/restore-contract/build.sh
@@ -4,7 +4,7 @@ set -e
 
 PROJNAME=restore_contract
 
-cargo +nightly build --release --target wasm32-unknown-unknown
+cargo +nightly-2020-10-01 build --release --target wasm32-unknown-unknown
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/yarn.lock
+++ b/yarn.lock
@@ -2335,7 +2335,7 @@ isomorphic-fetch@^2.2.1:
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
   dependencies:
-    node-fetch "^1.0.1"
+    node-fetch "^2.6.1"
     whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
@@ -3152,7 +3152,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^1.0.1:
+node-fetch@^2.6.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==


### PR DESCRIPTION
- pin the latest CI image that has `solang`, it doesn't compile after, this is temporary
- fix triggering from Substrate CI
- update dep based on dependabot security report

Closes paritytech/devops#449